### PR TITLE
feat: Add support for setting/adding entire tables/arrays

### DIFF
--- a/spec/parse_spec.lua
+++ b/spec/parse_spec.lua
@@ -79,27 +79,6 @@ describe("parse", function()
         local expected = toml_content:format("2.0.0")
         assert.equal(expected, tostring(result))
     end)
-    it("Can set value in array", function()
-        local toml_content = [[
-        my_arr = ["%s", "item2"]
-        ]]
-        local result = toml_edit.parse(toml_content)
-        result.my_arr[1] = "item1_changed"
-        local expected = toml_content:format("item1_changed")
-        assert.equal(expected, tostring(result))
-    end)
-    it("Can add value to array", function()
-        local toml_content = [[
-        my_arr = ["item1", "item2"]
-        ]]
-        local result = toml_edit.parse(toml_content)
-        result.my_arr[3] = "item3"
-        local new_toml_content = [[
-        my_arr = ["item1", "item2", "%s"]
-        ]]
-        local expected = new_toml_content:format("item3")
-        assert.equal(expected, tostring(result))
-    end)
     it("Can add value to table", function()
         local toml_content = [[
 [rocks.neorg]
@@ -112,6 +91,86 @@ version = "1.0.0"
 [rocks.neorg]
 version = "1.0.0"
 opt = false
+]]
+        assert.equal(expected, tostring(result))
+    end)
+    it("Can set entire table", function()
+        local toml_content = [[
+[rocks]
+
+[rocks.neorg]
+version = "1.0.0"
+]]
+        local result = toml_edit.parse(toml_content)
+        result.rocks = {
+            neorg = { version = "2.0.0", pin = true },
+        }
+        local expected = [[
+[rocks]
+
+[rocks.neorg]
+version = "2.0.0"
+pin = true
+]]
+        assert.equal(expected, tostring(result))
+    end)
+    it("Can add entire table", function()
+        local result = toml_edit.parse([[]])
+        result.rocks = {
+            neorg = { version = "2.0.0", pin = true },
+        }
+        local expected = [[
+[rocks]
+
+[rocks.neorg]
+version = "2.0.0"
+pin = true
+]]
+        assert.equal(expected, tostring(result))
+    end)
+    it("Can set value in array", function()
+        local toml_content = [[
+my_arr = ["%s", "item2"]
+]]
+        local result = toml_edit.parse(toml_content)
+        result.my_arr[1] = "item1_changed"
+        local expected = toml_content:format("item1_changed")
+        assert.equal(expected, tostring(result))
+    end)
+    it("Can add value to array", function()
+        local toml_content = [[
+my_arr = ["item1", "item2"]
+]]
+        local result = toml_edit.parse(toml_content)
+        result.my_arr[3] = "item3"
+        local expected = [[
+my_arr = ["item1", "item2", "item3"]
+]]
+        assert.equal(expected, tostring(result))
+    end)
+    it("Can set entire array", function()
+        local toml_content = [[
+my_arr = ["item1", "item2"]
+]]
+        local result = toml_edit.parse(toml_content)
+        result.my_arr = { "new_item1", "new_item2" }
+        local expected = [[
+my_arr = ["new_item1", "new_item2"]
+]]
+        assert.equal(expected, tostring(result))
+    end)
+    it("Cannot use complex types in lists", function()
+        local result = toml_edit.parse([[]])
+        assert.error(function()
+            result.my_arr = { { "new_item1" }, { "new_item2" } }
+        end)
+        assert.equal([[]], tostring(result))
+    end)
+    it("Can add entire array", function()
+        local result = toml_edit.parse([[]])
+        result.my_arr = { "new_item1", "new_item2" }
+        local expected = [[
+my_arr = ["new_item1", "new_item2"]
 ]]
         assert.equal(expected, tostring(result))
     end)


### PR DESCRIPTION
https://github.com/nvim-neorocks/toml-edit.lua/pull/38 Added support for reading and editing toml array values but there was no way to add an array into the toml document since it would always be interpreted as a table. This PR aims to add support for setting/adding entire tables (including nested tables) and arrays by looking at the keys of the lua table in the `__newindex` meta-method to determine which one it is. Note that just like the last PR, only arrays of basic value types are supported (no arrays of tables).