### PR TITLE
fix: don't treat empty table assignments as arrays by default

### DIFF
--- a/spec/parse_spec.lua
+++ b/spec/parse_spec.lua
@@ -79,6 +79,20 @@ describe("parse", function()
         local expected = toml_content:format("2.0.0")
         assert.equal(expected, tostring(result))
     end)
+    it("Can interatively build table", function()
+        local toml_content = [[]]
+        local result = toml_edit.parse(toml_content)
+        result.rocks = {}
+        result.rocks.neorg = {}
+        result.rocks.neorg.version = "1.0.0"
+        local expected = [[
+[rocks]
+
+[rocks.neorg]
+version = "1.0.0"
+]]
+        assert.equal(expected, tostring(result))
+    end)
     it("Can add value to table", function()
         local toml_content = [[
 [rocks.neorg]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,11 +288,15 @@ where
                             }
                             // Determine if table is array by checking the keys
                             let mut is_array = true;
-                            for table_pair in table.clone().pairs::<Value, Value>() {
-                                let (table_key, _) = table_pair?;
-                                if !table_key.is_integer() {
-                                    is_array = false;
-                                    break;
+                            if table.is_empty() {
+                                is_array = false;
+                            } else {
+                                for table_pair in table.clone().pairs::<Value, Value>() {
+                                    let (table_key, _) = table_pair?;
+                                    if !table_key.is_integer() {
+                                        is_array = false;
+                                        break;
+                                    }
                                 }
                             }
                             if is_array {


### PR DESCRIPTION
To address: https://github.com/nvim-neorocks/toml-edit.lua/pull/40#issuecomment-2462872031